### PR TITLE
Use true north reference frame when obtaining orientation updates

### DIFF
--- a/ios/RNSensorsOrientation.m
+++ b/ios/RNSensorsOrientation.m
@@ -89,7 +89,7 @@ RCT_EXPORT_METHOD(getUpdateInterval:(RCTResponseSenderBlock) cb) {
 
 RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     CMAttitude *attitude = self->_motionManager.deviceMotion.attitude;
-    
+
     double qx = attitude.quaternion.x;
     double qy = attitude.quaternion.y;
     double qz = attitude.quaternion.z;
@@ -128,10 +128,10 @@ RCT_EXPORT_METHOD(startUpdates) {
 
     /* Receive the orientation data on this block */
 		NSOperationQueue *queue = [[NSOperationQueue alloc] init];
-    [self->_motionManager startDeviceMotionUpdatesToQueue:queue withHandler:^(CMDeviceMotion *deviceMotion, NSError *error)
+    [self->_motionManager startDeviceMotionUpdatesUsingReferenceFrame:CMAttitudeReferenceFrameXTrueNorthZVertical toQueue:queue withHandler:^(CMDeviceMotion *deviceMotion, NSError *error)
      {
          CMAttitude *attitude = deviceMotion.attitude;
-         
+
          double qx = attitude.quaternion.x;
          double qy = attitude.quaternion.y;
          double qz = attitude.quaternion.z;


### PR DESCRIPTION
I noticed the returned yaw values were inaccurate, potentially b/c my device was using the [CMAttitudeReferenceFrameXArbitraryZVertical](https://developer.apple.com/documentation/coremotion/cmattitudereferenceframe/cmattitudereferenceframexarbitraryzvertical?language=objc) reference frame. This change ensures we always use the reference frame in which the device's X axis faces true north (the bottom of the device faces east).